### PR TITLE
Fixing fallback params

### DIFF
--- a/src/app/competition/chess/page.tsx
+++ b/src/app/competition/chess/page.tsx
@@ -1,22 +1,16 @@
-"use client"
+import BackButton from '@/components/back_button';
+import ChessUrlWrapper from '@/components/chess/chess_from_url';
+import defaultPage from '@/components/default';
+import { Suspense } from 'react';
 
-import { useSearchParams } from 'next/navigation';
-import BackButton from "@/components/back_button";
-import ChessBoard from "@/components/chess/board";
-import defaultPage from "@/components/default";
 
 export default function Home() {
-    const searchParams = useSearchParams();
-    const fenString = searchParams.get('fenString');
-
-    // Fallback to default position
-    const defaultFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    const boardFEN = fenString ? fenString : defaultFEN;
-
     return defaultPage(
-        <div>
-            <ChessBoard fenString={boardFEN} />
+        <>
+            <Suspense fallback={<div>Loading...</div>}>
+                <ChessUrlWrapper />
+            </Suspense>
             <BackButton />
-        </div>,
+        </>
     );
 }

--- a/src/components/chess/chess_from_url.tsx
+++ b/src/components/chess/chess_from_url.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+// Shitty wrapper because useSearchParams() can only be done in components?
+
+import { useSearchParams } from "next/navigation";
+import ChessBoard from "./board";
+import BackButton from "../back_button";
+
+
+export default function ChessUrlWrapper() {
+    const searchParams = useSearchParams();
+    const fenString = searchParams.get('fenString');
+
+    // Fallback to default position if no fenString is present
+    const defaultFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+    const boardFEN = fenString ? fenString : defaultFEN;
+
+    return (
+        <ChessBoard fenString={boardFEN} />
+    );
+}


### PR DESCRIPTION
Supid Next.js won't let you look at the url params if there isn't a fallback.... Which then has to also be in a strictly client-side component, not page. Why.